### PR TITLE
Add minimal Protoo WebSocket service

### DIFF
--- a/backend/src/bin/www.ts
+++ b/backend/src/bin/www.ts
@@ -129,6 +129,10 @@ async function startServer(): Promise<void> {
     await container.mediasoupService.initialize();
     logger.info('MediaSoup initialized successfully');
 
+    // Initialize protoo WebSocket server
+    container.protooService.initialize(server);
+    logger.info('Protoo server initialized');
+
     // Listen on provided port, on all network interfaces.
     server.listen(port);
     server.on('error', onError);

--- a/backend/src/domain/services/ProtooServiceInterface.ts
+++ b/backend/src/domain/services/ProtooServiceInterface.ts
@@ -1,0 +1,5 @@
+import { Server } from 'http';
+
+export interface ProtooServiceInterface {
+  initialize(httpServer: Server): void;
+}

--- a/backend/src/infrastructure/container.ts
+++ b/backend/src/infrastructure/container.ts
@@ -1,6 +1,7 @@
 import { InMemoryRoomRepository } from './repositories/InMemoryRoomRepository';
 import { InMemoryUserRepository } from './repositories/InMemoryUserRepository';
 import { MediasoupService } from './services/mediasoup/MediasoupService';
+import { ProtooService } from './services/protoo/ProtooService';
 import { RoomService } from './services/room/RoomService';
 import { CreateRoomUseCase } from '../application/usecases/room/CreateRoomUseCase';
 import { GetAllRoomsUseCase } from '../application/usecases/room/GetAllRoomsUseCase';
@@ -30,6 +31,7 @@ const roomRepository = new InMemoryRoomRepository(sampleRooms);
 // Create services
 const mediasoupService = new MediasoupService();
 const roomService = new RoomService(roomRepository, mediasoupService);
+const protooService = new ProtooService(roomService);
 
 // Create user use cases
 const getAllUsersUseCase = new GetAllUsersUseCase(userRepository);
@@ -62,6 +64,7 @@ export const container = {
   // Services
   mediasoupService,
   roomService,
+  protooService,
 
   // Use cases
   getAllUsersUseCase,

--- a/backend/src/infrastructure/services/protoo/ProtooService.ts
+++ b/backend/src/infrastructure/services/protoo/ProtooService.ts
@@ -1,0 +1,87 @@
+import { Server } from 'http';
+import * as protoo from 'protoo-server';
+
+import { RoomServiceInterface } from '../../../domain/services/RoomServiceInterface';
+import { ProtooServiceInterface } from '../../../domain/services/ProtooServiceInterface';
+import { logger } from '../../config/logger';
+
+export class ProtooService implements ProtooServiceInterface {
+  private _webSocketServer: protoo.WebSocketServer | null = null;
+  private readonly _peers: Map<string, Map<string, protoo.Peer>> = new Map();
+
+  constructor(private readonly _roomService: RoomServiceInterface) {}
+
+  public initialize(httpServer: Server): void {
+    this._webSocketServer = new protoo.WebSocketServer(httpServer);
+    this._webSocketServer.on(
+      'connectionrequest',
+      (
+        info: protoo.ConnectionRequestInfo,
+        accept: protoo.ConnectionRequestAcceptFn,
+        reject: protoo.ConnectionRequestRejectFn,
+      ) => {
+        void this.handleConnection(info, accept, reject);
+      },
+    );
+    logger.info('Protoo WebSocket server initialized');
+  }
+
+  private async handleConnection(
+    info: protoo.ConnectionRequestInfo,
+    accept: protoo.ConnectionRequestAcceptFn,
+    reject: protoo.ConnectionRequestRejectFn,
+  ): Promise<void> {
+    const url = new URL(info.request.url || '', 'http://localhost');
+    const roomId = url.searchParams.get('roomId');
+    const peerId = url.searchParams.get('peerId');
+
+    if (!roomId || !peerId) {
+      reject(400, 'roomId and peerId are required');
+      return;
+    }
+
+    const transport = accept();
+    const peer = new protoo.Peer(transport); // using direct Peer creation not recommended but we can use protoo default
+
+    let roomPeers = this._peers.get(roomId);
+    if (!roomPeers) {
+      roomPeers = new Map();
+      this._peers.set(roomId, roomPeers);
+    }
+    roomPeers.set(peerId, peer);
+
+    await this._roomService.addParticipant(roomId, peerId);
+    this.broadcast(roomId, 'participantJoined', { peerId }, peerId);
+
+    peer.on('request', (request, acceptRequest, rejectRequest) => {
+      if (request.method === 'ping') {
+        acceptRequest({ pong: true });
+      } else {
+        rejectRequest(new Error('unknown method'));
+      }
+    });
+
+    peer.on('close', () => {
+      roomPeers?.delete(peerId);
+      void this._roomService.removeParticipant(roomId, peerId);
+      this.broadcast(roomId, 'participantLeft', { peerId }, peerId);
+    });
+  }
+
+  private broadcast(
+    roomId: string,
+    method: string,
+    data: Record<string, unknown>,
+    excludePeerId?: string,
+  ): void {
+    const roomPeers = this._peers.get(roomId);
+    if (!roomPeers) return;
+
+    for (const [id, peer] of roomPeers.entries()) {
+      if (id === excludePeerId) continue;
+      peer
+        .notify(method, data)
+        .catch((error) => logger.warn(`Failed to notify peer ${id}`, error));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `ProtooServiceInterface`
- add basic `ProtooService` using protoo-server
- wire Protoo service into the container and server startup

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: packages field missing or empty)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module 'http')*

------
https://chatgpt.com/codex/tasks/task_e_684b82c9d224832f93809e92c9e68500