### PR TITLE
Implement WebRTC handlers

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -72,7 +72,8 @@
     "syncpack:check": "pnpx syncpack list-mismatches",
     "syncpack:fix": "pnpx syncpack fix-mismatches",
     "syncpack:format": "pnpx syncpack format",
-    "syncpack:lint": "pnpx syncpack lint"
+    "syncpack:lint": "pnpx syncpack lint",
+    "test": "NODE_PATH=./test/stubs npx tsx test/ProtooService.test.ts"
   },
   "type": "module"
 }

--- a/backend/src/infrastructure/services/protoo/ProtooService.ts
+++ b/backend/src/infrastructure/services/protoo/ProtooService.ts
@@ -1,13 +1,23 @@
 import { Server } from 'http';
 import * as protoo from 'protoo-server';
+import type { types as mediasoupTypes } from 'mediasoup';
+
+import { mediasoupConfig } from '../../config/mediasoup';
 
 import { RoomServiceInterface } from '../../../domain/services/RoomServiceInterface';
 import { ProtooServiceInterface } from '../../../domain/services/ProtooServiceInterface';
 import { logger } from '../../config/logger';
 
+export interface PeerMediaInfo {
+  peer: protoo.Peer;
+  transports: Map<string, mediasoupTypes.WebRtcTransport>;
+  producers: Map<string, mediasoupTypes.Producer>;
+  consumers: Map<string, mediasoupTypes.Consumer>;
+}
+
 export class ProtooService implements ProtooServiceInterface {
   private _webSocketServer: protoo.WebSocketServer | null = null;
-  private readonly _peers: Map<string, Map<string, protoo.Peer>> = new Map();
+  private readonly _peers: Map<string, Map<string, PeerMediaInfo>> = new Map();
 
   constructor(private readonly _roomService: RoomServiceInterface) {}
 
@@ -41,24 +51,34 @@ export class ProtooService implements ProtooServiceInterface {
     }
 
     const transport = accept();
-    const peer = new protoo.Peer(transport); // using direct Peer creation not recommended but we can use protoo default
+    const peer = new protoo.Peer(transport);
 
     let roomPeers = this._peers.get(roomId);
     if (!roomPeers) {
       roomPeers = new Map();
       this._peers.set(roomId, roomPeers);
     }
-    roomPeers.set(peerId, peer);
+
+    const peerInfo: PeerMediaInfo = {
+      peer,
+      transports: new Map(),
+      producers: new Map(),
+      consumers: new Map(),
+    };
+
+    roomPeers.set(peerId, peerInfo);
 
     await this._roomService.addParticipant(roomId, peerId);
     this.broadcast(roomId, 'participantJoined', { peerId }, peerId);
 
     peer.on('request', (request, acceptRequest, rejectRequest) => {
-      if (request.method === 'ping') {
-        acceptRequest({ pong: true });
-      } else {
-        rejectRequest(new Error('unknown method'));
-      }
+      void this.handleRequest(
+        roomId,
+        peerId,
+        request,
+        acceptRequest,
+        rejectRequest,
+      );
     });
 
     peer.on('close', () => {
@@ -77,11 +97,162 @@ export class ProtooService implements ProtooServiceInterface {
     const roomPeers = this._peers.get(roomId);
     if (!roomPeers) return;
 
-    for (const [id, peer] of roomPeers.entries()) {
+    for (const [id, info] of roomPeers.entries()) {
       if (id === excludePeerId) continue;
-      peer
+      info.peer
         .notify(method, data)
         .catch((error) => logger.warn(`Failed to notify peer ${id}`, error));
+    }
+  }
+
+  private async handleRequest(
+    roomId: string,
+    peerId: string,
+    request: protoo.Request,
+    accept: (data?: Record<string, unknown>) => void,
+    reject: (error?: Error) => void,
+  ): Promise<void> {
+    const roomPeers = this._peers.get(roomId);
+    const peerInfo = roomPeers?.get(peerId);
+
+    if (!peerInfo) {
+      reject(new Error('peer not found'));
+      return;
+    }
+
+    try {
+      switch (request.method) {
+        case 'ping':
+          accept({ pong: true });
+          break;
+        case 'getRouterRtpCapabilities': {
+          await this._roomService.getOrCreateRoom(roomId);
+          const router = this._roomService.getRouter(roomId);
+          if (!router) throw new Error('router not found');
+          const internal = router.internal as mediasoupTypes.Router;
+          accept({ rtpCapabilities: internal.rtpCapabilities });
+          break;
+        }
+        case 'createWebRtcTransport': {
+          const router = this._roomService.getRouter(roomId);
+          if (!router) throw new Error('router not found');
+          const internal = router.internal as mediasoupTypes.Router;
+          const transport = await internal.createWebRtcTransport({
+            listenIps: mediasoupConfig.webRtcTransport.listenIps,
+            enableUdp: true,
+            enableTcp: true,
+            preferUdp: true,
+            initialAvailableOutgoingBitrate:
+              mediasoupConfig.webRtcTransport.initialAvailableOutgoingBitrate,
+            enableSctp: true,
+            numSctpStreams: { OS: 1024, MIS: 1024 },
+            appData: { peerId },
+          });
+
+          peerInfo.transports.set(transport.id, transport);
+
+          accept({
+            id: transport.id,
+            iceParameters: transport.iceParameters,
+            iceCandidates: transport.iceCandidates,
+            dtlsParameters: transport.dtlsParameters,
+          });
+          break;
+        }
+        case 'connectWebRtcTransport': {
+          const { transportId, dtlsParameters } = request.data || {};
+          if (!transportId || !dtlsParameters) {
+            throw new Error('missing data');
+          }
+          const transport = peerInfo.transports.get(String(transportId));
+          if (!transport) throw new Error('transport not found');
+          await transport.connect({ dtlsParameters: dtlsParameters as mediasoupTypes.DtlsParameters });
+          accept({ success: true });
+          break;
+        }
+        case 'produce': {
+          const { transportId, kind, rtpParameters, appData } = request.data || {};
+          if (!transportId || !kind || !rtpParameters) {
+            throw new Error('missing data');
+          }
+          const transport = peerInfo.transports.get(String(transportId));
+          if (!transport) throw new Error('transport not found');
+          const producer = await transport.produce({
+            kind: kind as mediasoupTypes.MediaKind,
+            rtpParameters: rtpParameters as mediasoupTypes.RtpParameters,
+            appData: appData as mediasoupTypes.AppData,
+          });
+          peerInfo.producers.set(producer.id, producer);
+
+          if (appData && (appData as Record<string, unknown>).mediaType === 'screen') {
+            this.broadcast(roomId, 'screenSharingStarted', { peerId, producerId: producer.id }, peerId);
+          }
+
+          accept({ id: producer.id });
+          break;
+        }
+        case 'consume': {
+          const { transportId, producerId, rtpCapabilities } = request.data || {};
+          if (!transportId || !producerId || !rtpCapabilities) {
+            throw new Error('missing data');
+          }
+          const router = this._roomService.getRouter(roomId);
+          if (!router) throw new Error('router not found');
+          const internal = router.internal as mediasoupTypes.Router;
+          if (!internal.canConsume({ producerId: String(producerId), rtpCapabilities: rtpCapabilities as mediasoupTypes.RtpCapabilities })) {
+            throw new Error('cannot consume');
+          }
+          const transport = peerInfo.transports.get(String(transportId));
+          if (!transport) throw new Error('transport not found');
+          const consumer = await transport.consume({
+            producerId: String(producerId),
+            rtpCapabilities: rtpCapabilities as mediasoupTypes.RtpCapabilities,
+            paused: true,
+          });
+          peerInfo.consumers.set(consumer.id, consumer);
+          accept({
+            id: consumer.id,
+            producerId: String(producerId),
+            kind: consumer.kind,
+            rtpParameters: consumer.rtpParameters,
+          });
+          break;
+        }
+        case 'resumeConsumer': {
+          const { consumerId } = request.data || {};
+          if (!consumerId) throw new Error('missing consumerId');
+          const consumer = peerInfo.consumers.get(String(consumerId));
+          if (!consumer) throw new Error('consumer not found');
+          await consumer.resume();
+          accept({ success: true });
+          break;
+        }
+        case 'getParticipants': {
+          const participants = await this._roomService.getRoomParticipants(roomId);
+          accept({ participants });
+          break;
+        }
+        case 'closeProducer': {
+          const { producerId } = request.data || {};
+          if (!producerId) throw new Error('missing producerId');
+          const producer = peerInfo.producers.get(String(producerId));
+          if (producer) {
+            const isScreen = (producer.appData as Record<string, unknown> | undefined)?.mediaType === 'screen';
+            producer.close();
+            peerInfo.producers.delete(String(producerId));
+            if (isScreen) {
+              this.broadcast(roomId, 'screenSharingStopped', { peerId, producerId: String(producerId) }, peerId);
+            }
+          }
+          accept({ success: true });
+          break;
+        }
+        default:
+          reject(new Error('unknown method'));
+      }
+    } catch (error) {
+      logger.error('protoo request error', error);
+      reject(error instanceof Error ? error : new Error('unknown error'));
     }
   }
 }

--- a/backend/test/ProtooService.test.ts
+++ b/backend/test/ProtooService.test.ts
@@ -1,0 +1,77 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import { ProtooService } from '../src/infrastructure/services/protoo/ProtooService';
+import type { RoomServiceInterface } from '../src/domain/services/RoomServiceInterface';
+
+class FakeTransport {
+  public id = `t-${Math.random()}`;
+  public iceParameters = {};
+  public iceCandidates: unknown[] = [];
+  public dtlsParameters = {};
+  public connected = false;
+  async connect(): Promise<void> { this.connected = true; }
+  async produce(opts: any): Promise<any> { return { id: `p-${Math.random()}`, kind: opts.kind, rtpParameters: opts.rtpParameters, appData: opts.appData, close: () => {} }; }
+  async consume(opts: any): Promise<any> { return { id: `c-${Math.random()}`, producerId: opts.producerId, kind: 'video', rtpParameters: {}, resume: async () => {} }; }
+}
+
+class FakeRouter {
+  public rtpCapabilities = { codecs: [] };
+  async createWebRtcTransport(): Promise<any> { return new FakeTransport(); }
+  canConsume(): boolean { return true; }
+}
+
+class MockRoomService implements RoomServiceInterface {
+  public participants = new Set<string>();
+  public router = { id: 'r1', roomId: 'room1', internal: new FakeRouter() };
+  async createRoom(): Promise<any> { return {}; }
+  async getOrCreateRoom(): Promise<any> { return {}; }
+  getRouter(): any { return this.router; }
+  async addParticipant(_: string, peerId: string): Promise<void> { this.participants.add(peerId); }
+  async removeParticipant(_: string, peerId: string): Promise<void> { this.participants.delete(peerId); }
+  async closeRoom(): Promise<void> {}
+  async getRoomParticipants(): Promise<string[]> { return Array.from(this.participants); }
+}
+
+function createService() {
+  const roomService = new MockRoomService();
+  const service = new ProtooService(roomService);
+  (service as any)._peers.set('room1', new Map([
+    ['peer1', { peer: {} as any, transports: new Map(), producers: new Map(), consumers: new Map() }]
+  ]));
+  return { service, roomService };
+}
+
+async function request(service: ProtooService, method: string, data?: any) {
+  let res: any; let err: any;
+  await (service as any).handleRequest('room1', 'peer1', { method, data }, (d?: any) => { res = d; }, (e?: any) => { err = e; });
+  if (err) throw err;
+  return res;
+}
+
+test('getRouterRtpCapabilities', async () => {
+  const { service } = createService();
+  const resp = await request(service, 'getRouterRtpCapabilities');
+  assert.deepEqual(resp, { rtpCapabilities: { codecs: [] } });
+});
+
+test('create/connect transport and produce/consume', async () => {
+  const { service } = createService();
+  const tResp = await request(service, 'createWebRtcTransport');
+  assert.ok(tResp.id);
+  await request(service, 'connectWebRtcTransport', { transportId: tResp.id, dtlsParameters: {} });
+  const pResp = await request(service, 'produce', { transportId: tResp.id, kind: 'video', rtpParameters: {}, appData: {} });
+  assert.ok(pResp.id);
+  const t2 = await request(service, 'createWebRtcTransport');
+  const cResp = await request(service, 'consume', { transportId: t2.id, producerId: pResp.id, rtpCapabilities: {} });
+  assert.ok(cResp.id);
+  await request(service, 'resumeConsumer', { consumerId: cResp.id });
+  await request(service, 'closeProducer', { producerId: pResp.id });
+});
+
+test('getParticipants', async () => {
+  const { service, roomService } = createService();
+  roomService.participants.add('peer1');
+  const resp = await request(service, 'getParticipants');
+  assert.deepEqual(resp, { participants: ['peer1'] });
+});

--- a/backend/test/stubs/protoo-server/index.js
+++ b/backend/test/stubs/protoo-server/index.js
@@ -1,0 +1,10 @@
+class Peer {
+  constructor() {}
+  on() {}
+  notify() { return Promise.resolve(); }
+}
+class WebSocketServer {
+  constructor() {}
+  on() {}
+}
+module.exports = { Peer, WebSocketServer };

--- a/backend/test/stubs/protoo-server/package.json
+++ b/backend/test/stubs/protoo-server/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "protoo-server",
+  "main": "index.js",
+  "type": "commonjs"
+}

--- a/backend/test/stubs/winston/index.js
+++ b/backend/test/stubs/winston/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  createLogger: () => ({ info() {}, warn() {}, error() {}, debug() {} }),
+  format: { combine: () => {}, timestamp: () => {}, printf: () => {}, colorize: () => {}, errors: () => {} },
+  transports: { Console: function() {}, File: function() {} }
+};

--- a/backend/test/stubs/winston/package.json
+++ b/backend/test/stubs/winston/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "winston",
+  "main": "index.js",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- extend `ProtooService` with WebRTC handler logic
- add stubbed unit tests for new handlers
- provide local stubs for external dependencies

## Testing
- `npm test` *(fails: Cannot find package 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684b8ec89bdc832fbcf985294af233fe